### PR TITLE
fix(web): secure longform publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 **Project:** ProjektKraken  
 **Document:** Project Changelog  
 **Last Updated:** 2026-08-03
-**Commit:** 3c46f49b
+**Commit:** a3eb5949
 ---
 
 # Changelog
@@ -11,8 +11,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- *(2026-08-03)* **Longform / LAN Sharing**: Added explicit authenticated LAN
+  publishing with ephemeral eight-digit access codes and brute-force limits.
+
+### Fixed
+
+- *(2026-08-03)* **Longform / Security**: Restricted default publishing to
+  localhost and made HTTP longform reads unable to modify world databases.
+
 ### Changed
 
+- *(2026-08-03)* **Testing / Security**: Added authentication, binding,
+  read-only database, identifier-validation, and publishing UI regressions.
 - *(2026-08-03)* **Release**: Bumped project and application metadata to
   version 0.18.7.
 

--- a/src/gui/widgets/longform/editor.py
+++ b/src/gui/widgets/longform/editor.py
@@ -5,6 +5,7 @@ Provides a split-view interface for editing longform documents:
 - Right: Continuous document view (from content.py)
 """
 
+import html
 import logging
 import os
 from typing import Any, Dict, List, Optional
@@ -128,18 +129,25 @@ class LongformEditorWidget(QWidget):
         btn_export_vault.clicked.connect(self.export_vault_requested.emit)
         toolbar.addWidget(btn_export_vault)
 
-        # Publish Button
-        self.btn_publish = QPushButton("Publish to Web")
+        # Local publishing is the safe, frictionless default. LAN sharing is a
+        # separate action because it changes the server's network exposure.
+        self.btn_publish = QPushButton("Publish Locally")
         self.btn_publish.setCheckable(True)
         self.btn_publish.clicked.connect(self._toggle_publish)
         toolbar.addWidget(self.btn_publish)
 
+        self.btn_share_lan = QPushButton("Share on LAN...")
+        self.btn_share_lan.setCheckable(True)
+        self.btn_share_lan.clicked.connect(self._toggle_lan_share)
+        toolbar.addWidget(self.btn_share_lan)
+
         self.url_label = QLabel("")
-        self.url_label.setStyleSheet(
-            "color: #FF9900; margin-left: 10px; font-weight: bold;"
-        )
+        self.url_label.setStyleSheet(StyleHelper.get_wiki_link_style())
         self.url_label.setOpenExternalLinks(True)
         toolbar.addWidget(self.url_label)
+
+        self.access_code_label = QLabel("")
+        toolbar.addWidget(self.access_code_label)
 
         # Spacer to push Find button to far right
         spacer = QWidget()
@@ -329,32 +337,75 @@ class LongformEditorWidget(QWidget):
 
     @Slot(bool)
     def _toggle_publish(self, checked: bool) -> None:
-        """Handle publish toggle."""
+        """Handle localhost-only publishing."""
         if checked:
-            self.web_manager.start_server(db_path=self.db_path)
-        else:
+            if self.web_manager.is_running:
+                self.web_manager.stop_server()
+            self.web_manager.start_server(db_path=self.db_path, share_on_lan=False)
+        elif self.web_manager.is_running and not self.web_manager.is_lan_shared:
             self.web_manager.stop_server()
+
+    @Slot(bool)
+    def _toggle_lan_share(self, checked: bool) -> None:
+        """Start or stop explicit authenticated LAN sharing."""
+        if not checked:
+            if self.web_manager.is_lan_shared:
+                self.web_manager.stop_server()
+            return
+
+        answer = QMessageBox.question(
+            self,
+            "Share Longform on LAN",
+            "Other devices on this local network can open the published longform "
+            "after entering the generated access code. Continue?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if answer != QMessageBox.StandardButton.Yes:
+            self.btn_share_lan.setChecked(False)
+            return
+
+        if self.web_manager.is_running:
+            self.web_manager.stop_server()
+        self.web_manager.start_server(db_path=self.db_path, share_on_lan=True)
 
     @Slot(bool, str)
     def _on_server_status_changed(self, is_running: bool, url: str) -> None:
         """Update UI based on server status."""
-        self.btn_publish.setChecked(is_running)
+        is_lan_shared = is_running and self.web_manager.is_lan_shared
+        self.btn_publish.setChecked(is_running and not is_lan_shared)
+        self.btn_share_lan.setChecked(is_lan_shared)
         if is_running:
-            self.btn_publish.setText("Stop Publishing")
+            self.btn_publish.setText(
+                "Stop Local Publishing" if not is_lan_shared else "Publish Locally"
+            )
+            self.btn_share_lan.setText(
+                "Stop LAN Sharing" if is_lan_shared else "Share on LAN..."
+            )
             # Create a clickable link
+            escaped_url = html.escape(url, quote=True)
             self.url_label.setText(
-                f'<a href="{url}" style="color: #FF9900; text-decoration: none;">'
-                f"{url}</a>"
+                f'<a href="{escaped_url}">{escaped_url}</a>'
             )
             self.url_label.setToolTip("Click to open in browser")
+            access_code = self.web_manager.access_code
+            if access_code:
+                formatted_code = f"{access_code[:4]} {access_code[4:]}"
+                self.access_code_label.setText(f"Access code: {formatted_code}")
+            else:
+                self.access_code_label.setText("")
         else:
-            self.btn_publish.setText("Publish to Web")
+            self.btn_publish.setText("Publish Locally")
+            self.btn_share_lan.setText("Share on LAN...")
             self.url_label.setText("")
+            self.access_code_label.setText("")
 
     @Slot(str)
     def _on_server_error(self, msg: str) -> None:
         """Handle server error manually."""
         self.btn_publish.setChecked(False)
+        self.btn_share_lan.setChecked(False)
+        self.access_code_label.setText("")
         self.url_label.setText("Error starting server")
         QMessageBox.warning(self, "Web Server Error", msg)
 

--- a/src/services/db_service.py
+++ b/src/services/db_service.py
@@ -58,6 +58,7 @@ class DatabaseService:
         self,
         db_path: str = ":memory:",
         *,
+        read_only: bool = False,
         event_repo: Optional[EventRepository] = None,
         entity_repo: Optional[EntityRepository] = None,
         relation_repo: Optional[RelationRepository] = None,
@@ -73,6 +74,8 @@ class DatabaseService:
         Args:
             db_path: Path to the .kraken database file.
                      Defaults to :memory: for testing.
+            read_only: Open an existing database without permitting writes or
+                running schema initialization and migrations.
             event_repo: Optional EventRepository instance (injected for testing).
             entity_repo: Optional EntityRepository instance.
             relation_repo: Optional RelationRepository instance.
@@ -85,6 +88,7 @@ class DatabaseService:
 
         """
         self.db_path = db_path
+        self.read_only = read_only
         self._connection: Optional[sqlite3.Connection] = None
         self._backup_service = None
 
@@ -104,17 +108,25 @@ class DatabaseService:
     def connect(self) -> None:
         """Establishes connection to the database."""
         try:
-            self._connection = sqlite3.connect(self.db_path)
+            if self.read_only:
+                if self.db_path == ":memory:":
+                    raise ValueError("Read-only databases must use a file path")
+                database_uri = f"{Path(self.db_path).resolve().as_uri()}?mode=ro"
+                self._connection = sqlite3.connect(database_uri, uri=True)
+                self._connection.execute("PRAGMA query_only = ON;")
+            else:
+                self._connection = sqlite3.connect(self.db_path)
             self._connection.execute("PRAGMA foreign_keys = ON;")
-            if self.db_path != ":memory:":
+            if not self.read_only and self.db_path != ":memory:":
                 # WAL enables concurrent reads during background writes
                 self._connection.execute("PRAGMA journal_mode=WAL;")
                 logger.debug("WAL mode enabled for database.")
             self._connection.row_factory = sqlite3.Row
             logger.debug("Database connection established.")
 
-            self._init_schema()
-            self._run_migrations()
+            if not self.read_only:
+                self._init_schema()
+                self._run_migrations()
 
             # Connect repositories to the database connection
             self._event_repo.set_connection(self._connection)

--- a/src/services/longform_builder.py
+++ b/src/services/longform_builder.py
@@ -18,6 +18,7 @@ in Python layer to maintain SQLite compatibility.
 
 import json
 import logging
+import re
 from sqlite3 import Connection
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -25,10 +26,33 @@ logger = logging.getLogger(__name__)
 
 # Constants
 DOC_ID_DEFAULT = "default"
+DOC_ID_MAX_LENGTH = 64
 DEFAULT_POSITION_GAP = 100.0
+_DOC_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 
 # Security: Whitelist of valid table names to prevent SQL injection
 VALID_TABLES = ("events", "entities")
+
+
+def validate_doc_id(doc_id: str) -> str:
+    """Validate and return a bounded longform document identifier.
+
+    Args:
+        doc_id: Document identifier supplied by an internal or external caller.
+
+    Returns:
+        The validated document identifier.
+
+    Raises:
+        ValueError: If the identifier is empty, too long, or contains unsupported
+            characters.
+
+    """
+    if len(doc_id) > DOC_ID_MAX_LENGTH or not _DOC_ID_PATTERN.fullmatch(doc_id):
+        raise ValueError(
+            "doc_id must be 1-64 ASCII letters, digits, underscores, or hyphens"
+        )
+    return doc_id
 
 
 def _validate_table_name(table: str) -> None:
@@ -83,6 +107,7 @@ def _get_longform_meta(
         Optional[dict]: Longform metadata dict or None if not present.
 
     """
+    validate_doc_id(doc_id)
     lf_data = attributes.get("_longform")
     if not isinstance(lf_data, dict):
         return None
@@ -103,6 +128,7 @@ def _set_longform_meta(
         dict: Updated attributes dictionary.
 
     """
+    validate_doc_id(doc_id)
     if "_longform" not in attributes or not isinstance(attributes["_longform"], dict):
         attributes["_longform"] = {}
     attributes["_longform"][doc_id] = meta
@@ -125,6 +151,7 @@ def read_all_longform_items(
                     attributes (dict), meta (dict).
 
     """
+    validate_doc_id(doc_id)
     items = []
 
     # Read events
@@ -260,7 +287,8 @@ def build_longform_sequence(
     Computes heading_level based on parent-child relationships and depth.
     Returns items in reading order.
 
-    Automatically adds missing DB items to the end of the document.
+    This function is read-only. Call :func:`ensure_all_items_indexed` explicitly
+    from a trusted mutation path when the document should be auto-populated.
 
     Args:
         conn: SQLite connection.
@@ -271,11 +299,6 @@ def build_longform_sequence(
                     Each item includes: table, id, name, content, meta, heading_level.
 
     """
-    # 0. Sync check: ensure everything is in the doc
-    # Skip this if we are filtering, as we don't want to auto-add items
-    if allowed_ids is None:
-        ensure_all_items_indexed(conn, doc_id)
-
     items = read_all_longform_items(conn, doc_id, allowed_ids=allowed_ids)
 
     # Build parent-child map
@@ -497,6 +520,7 @@ def reindex_document_positions(conn: Connection, doc_id: str = DOC_ID_DEFAULT) -
         doc_id: Document ID.
 
     """
+    ensure_all_items_indexed(conn, doc_id)
     sequence = build_longform_sequence(conn, doc_id)
 
     for idx, item in enumerate(sequence):
@@ -694,6 +718,7 @@ def export_longform_to_markdown(conn: Connection, doc_id: str = DOC_ID_DEFAULT) 
         str: Markdown-formatted document.
 
     """
+    ensure_all_items_indexed(conn, doc_id)
     sequence = build_longform_sequence(conn, doc_id)
 
     lines = []

--- a/src/services/web_service_manager.py
+++ b/src/services/web_service_manager.py
@@ -4,6 +4,7 @@ Handles the lifecycle of the embedded Uvicorn server within a QThread.
 """
 
 import logging
+import secrets
 import socket
 import threading
 from typing import Optional
@@ -106,6 +107,16 @@ class WebServiceManager(QObject):
         """
         return self._thread is not None and self._thread.isRunning()
 
+    @property
+    def is_lan_shared(self) -> bool:
+        """Return whether the active server is accepting authenticated LAN access."""
+        return self._thread is not None and self._config.lan_access
+
+    @property
+    def access_code(self) -> Optional[str]:
+        """Return the active ephemeral LAN access code, if one exists."""
+        return self._config.access_code if self.is_lan_shared else None
+
     def get_local_ip(self) -> str:
         """Get the local IP address for LAN access."""
         try:
@@ -120,23 +131,39 @@ class WebServiceManager(QObject):
             # Network unavailable or other error - use localhost
             return "127.0.0.1"
 
-    def start_server(self, port: int = 8000, db_path: Optional[str] = None) -> None:
-        """Start the web server."""
+    def start_server(
+        self,
+        port: int = 8000,
+        db_path: Optional[str] = None,
+        *,
+        share_on_lan: bool = False,
+    ) -> None:
+        """Start a localhost-only server or an authenticated LAN server."""
         if self.is_running:
             return
 
-        self._config.port = port
-        if db_path:
-            self._config.db_path = db_path
+        target_db_path = db_path or self._config.db_path
 
         # Capture active theme from Qt main thread before handing off to the
         # background uvicorn thread (ThemeManager is a Qt singleton).
         try:
             from src.core.theme_manager import ThemeManager
 
-            self._config.theme_name = ThemeManager().current_theme_name
+            theme_name = ThemeManager().current_theme_name
         except Exception:
-            self._config.theme_name = "dark_mode"
+            theme_name = "dark_mode"
+
+        access_code = (
+            f"{secrets.randbelow(100_000_000):08d}" if share_on_lan else None
+        )
+        self._config = ServerConfig(
+            host="0.0.0.0" if share_on_lan else "127.0.0.1",
+            port=port,
+            db_path=target_db_path,
+            theme_name=theme_name,
+            lan_access=share_on_lan,
+            access_code=access_code,
+        )
 
         self._thread = WebServerThread(self._config)
         self._thread.error_occurred.connect(self._on_thread_error)
@@ -147,10 +174,15 @@ class WebServiceManager(QObject):
         # Wait a moment to check if it crashes immediately?
         # No, async signals will handle it.
 
-        ip = self.get_local_ip()
+        ip = self.get_local_ip() if share_on_lan else "127.0.0.1"
         url = f"http://{ip}:{port}/longform"
         self.status_changed.emit(True, url)
-        logger.info(f"Web server started at {url}")
+        logger.info(
+            "Web server started on %s:%s (%s mode)",
+            self._config.host,
+            port,
+            "LAN" if share_on_lan else "local",
+        )
 
     def stop_server(self) -> None:
         """Stop the web server."""
@@ -158,6 +190,7 @@ class WebServiceManager(QObject):
             logger.info("Stopping web server...")
             self._thread.stop()
             self._thread = None
+            self._clear_access_code()
             self.status_changed.emit(False, "")
 
     def toggle_server(self) -> None:
@@ -189,3 +222,12 @@ class WebServiceManager(QObject):
         if self._thread:  # If finished unexpectedly
             self.status_changed.emit(False, "")
             self._thread = None
+            self._clear_access_code()
+
+    def _clear_access_code(self) -> None:
+        """Discard LAN credentials while retaining the last database selection."""
+        self._config = ServerConfig(
+            db_path=self._config.db_path,
+            port=self._config.port,
+            theme_name=self._config.theme_name,
+        )

--- a/src/services/worker.py
+++ b/src/services/worker.py
@@ -567,6 +567,8 @@ class DatabaseWorker(QObject):
                 raise RuntimeError("Failed to establish database connection")
             self.db_service.ensure_fresh_view()
 
+            if allowed_ids is None:
+                longform_builder.ensure_all_items_indexed(connection, doc_id)
             sequence = longform_builder.build_longform_sequence(
                 connection, doc_id=doc_id, allowed_ids=allowed_ids
             )

--- a/src/webserver/config.py
+++ b/src/webserver/config.py
@@ -1,5 +1,6 @@
 """Configuration helpers for the Longform web server."""
 
+import re
 from dataclasses import dataclass
 
 
@@ -8,16 +9,25 @@ class ServerConfig:
     """Configuration for the embedded web server.
 
     Attributes:
-        host: Host address to bind to (default: 0.0.0.0 for all interfaces).
+        host: Host address to bind to (default: localhost only).
         port: Port number to listen on (default: 8000).
         db_path: Path to the database file to serve data from.
         poll_interval_ms: Reserved for future live-reload polling (unused).
         theme_name: Name of the active theme at server start (from ThemeManager).
+        lan_access: Whether requests to API endpoints require an access code.
+        access_code: Ephemeral eight-digit access code for LAN mode.
 
     """
 
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 8000
     db_path: str = "world.kraken"
     poll_interval_ms: int = 5000
     theme_name: str = "dark_mode"
+    lan_access: bool = False
+    access_code: str | None = None
+
+    def __post_init__(self) -> None:
+        """Reject incomplete or malformed LAN authentication configuration."""
+        if self.lan_access and not re.fullmatch(r"\d{8}", self.access_code or ""):
+            raise ValueError("LAN access requires an eight-digit access code")

--- a/src/webserver/server.py
+++ b/src/webserver/server.py
@@ -9,30 +9,99 @@ import json
 import logging
 import os
 import re
+import secrets
 import sys
+import threading
+import time
+from collections import defaultdict, deque
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 import markdown  # type: ignore[import-untyped]  # Package has no py.typed marker.
-from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from src.services.db_service import DatabaseService
-from src.services.longform_builder import build_longform_sequence
+from src.services.longform_builder import (
+    DOC_ID_DEFAULT,
+    DOC_ID_MAX_LENGTH,
+    build_longform_sequence,
+)
 from src.webserver.config import ServerConfig
 
 logger = logging.getLogger(__name__)
 
 logging.getLogger("MARKDOWN").setLevel(logging.WARNING)
 
-_config: ServerConfig = ServerConfig()
+_DOC_ID_QUERY_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$"
+DocId = Annotated[
+    str,
+    Query(
+        min_length=1,
+        max_length=DOC_ID_MAX_LENGTH,
+        pattern=_DOC_ID_QUERY_PATTERN,
+    ),
+]
 
 
-def get_db_service() -> DatabaseService:
+class _AccessCodeRateLimiter:
+    """Bound failed LAN authentication attempts in a rolling time window."""
+
+    _WINDOW_SECONDS = 60.0
+    _CLIENT_LIMIT = 5
+    _GLOBAL_LIMIT = 30
+
+    def __init__(self) -> None:
+        self._client_failures: dict[str, deque[float]] = defaultdict(deque)
+        self._global_failures: deque[float] = deque()
+        self._lock = threading.Lock()
+
+    def record_failure(self, client: str) -> int | None:
+        """Record a failed attempt and return a retry delay when limited."""
+        now = time.monotonic()
+        with self._lock:
+            client_failures = self._client_failures[client]
+            self._prune(client_failures, now)
+            self._prune(self._global_failures, now)
+            client_failures.append(now)
+            self._global_failures.append(now)
+            return self._retry_after(client_failures, now)
+
+    def retry_after(self, client: str) -> int | None:
+        """Return the active retry delay for a client, if any."""
+        now = time.monotonic()
+        with self._lock:
+            client_failures = self._client_failures[client]
+            self._prune(client_failures, now)
+            self._prune(self._global_failures, now)
+            return self._retry_after(client_failures, now)
+
+    def _retry_after(self, client_failures: deque[float], now: float) -> int | None:
+        limited_at: float | None = None
+        if len(client_failures) >= self._CLIENT_LIMIT:
+            limited_at = client_failures[0]
+        if len(self._global_failures) >= self._GLOBAL_LIMIT:
+            global_limited_at = self._global_failures[0]
+            limited_at = (
+                global_limited_at
+                if limited_at is None
+                else min(limited_at, global_limited_at)
+            )
+        if limited_at is None:
+            return None
+        return max(1, int(self._WINDOW_SECONDS - (now - limited_at)) + 1)
+
+    def _prune(self, failures: deque[float], now: float) -> None:
+        cutoff = now - self._WINDOW_SECONDS
+        while failures and failures[0] <= cutoff:
+            failures.popleft()
+
+
+def get_db_service(config: ServerConfig) -> DatabaseService:
     """Create a new DatabaseService instance for the current request."""
-    service = DatabaseService(db_path=_config.db_path)
+    service = DatabaseService(db_path=config.db_path, read_only=True)
     service.connect()
     return service
 
@@ -105,12 +174,52 @@ def _resolve_wikilinks(text: str) -> str:
     return text
 
 
+def _install_lan_authentication(app: FastAPI, config: ServerConfig) -> None:
+    """Install API authentication when the server is explicitly shared on LAN."""
+    rate_limiter = _AccessCodeRateLimiter()
+
+    @app.middleware("http")
+    async def authenticate_lan_api(request: Request, call_next: Any) -> Any:
+        """Require the ephemeral access code for every LAN API request."""
+        if not config.lan_access or not request.url.path.startswith("/api/"):
+            return await call_next(request)
+
+        client = request.client.host if request.client else "unknown"
+        retry_after = rate_limiter.retry_after(client)
+        if retry_after is not None:
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Too many access-code attempts"},
+                headers={"Retry-After": str(retry_after)},
+            )
+
+        authorization = request.headers.get("Authorization", "")
+        scheme, _, supplied_code = authorization.partition(" ")
+        expected_code = config.access_code or ""
+        authenticated = scheme.lower() == "bearer" and secrets.compare_digest(
+            supplied_code, expected_code
+        )
+        if authenticated:
+            return await call_next(request)
+
+        retry_after = rate_limiter.record_failure(client)
+        if retry_after is not None:
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Too many access-code attempts"},
+                headers={"Retry-After": str(retry_after)},
+            )
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "A valid LAN access code is required"},
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
 def create_app(config: ServerConfig) -> FastAPI:
     """Factory function to create the FastAPI app with the given configuration."""
-    global _config
-    _config = config
-
     app = FastAPI(title="ProjektKraken Longform Server")
+    _install_lan_authentication(app, config)
 
     static_dir = os.path.join(os.path.dirname(__file__), "static")
     app.mount("/static", StaticFiles(directory=static_dir), name="static")
@@ -130,7 +239,7 @@ def create_app(config: ServerConfig) -> FastAPI:
             JSON object with ``tags`` list of tag name strings.
 
         """
-        db = get_db_service()
+        db = get_db_service(config)
         try:
             tags_data = db.get_active_tags()
             tags = sorted([t["name"] for t in tags_data])
@@ -161,16 +270,16 @@ def create_app(config: ServerConfig) -> FastAPI:
             logger.error(f"Could not load themes.json from {themes_path}: {e}")
             themes = {}
         return {
-            "active_theme": _config.theme_name,
+            "active_theme": config.theme_name,
             "themes": themes,
         }
 
     @app.get("/api/longform")
     def get_longform(
-        doc_id: str = "default", filter_json: str | None = None
+        doc_id: DocId = DOC_ID_DEFAULT, filter_json: str | None = None
     ) -> dict[str, Any]:
         """Get the structured longform sequence as JSON with rendered HTML."""
-        db = get_db_service()
+        db = get_db_service(config)
         try:
             allowed_ids = _resolve_filter(filter_json, db)
 
@@ -217,10 +326,10 @@ def create_app(config: ServerConfig) -> FastAPI:
 
     @app.get("/api/toc")
     def get_toc(
-        doc_id: str = "default", filter_json: str | None = None
+        doc_id: DocId = DOC_ID_DEFAULT, filter_json: str | None = None
     ) -> list[dict[str, Any]]:
         """Get just the Table of Contents structure, with optional filter."""
-        db = get_db_service()
+        db = get_db_service(config)
         try:
             allowed_ids = _resolve_filter(filter_json, db)
             assert db._connection is not None, "Database not connected"
@@ -255,7 +364,10 @@ def create_app(config: ServerConfig) -> FastAPI:
         return templates.TemplateResponse(
             request,
             "index.html",
-            {"initial_theme": _config.theme_name},
+            {
+                "initial_theme": config.theme_name,
+                "lan_access": config.lan_access,
+            },
         )
 
     @app.get("/health")

--- a/src/webserver/static/app.js
+++ b/src/webserver/static/app.js
@@ -49,6 +49,8 @@ const state = {
     dropdownIndex: -1,
     filteredCandidates: [],
     tocObserver: null,
+    lanAccess: window.__LAN_ACCESS__ || false,
+    accessCode: '',
 };
 
 const dom = {};
@@ -60,6 +62,20 @@ document.addEventListener('DOMContentLoaded', init);
 
 async function init() {
     cacheDom();
+    attachAccessGate();
+    if (state.lanAccess) {
+        state.accessCode = sessionStorage.getItem('krakenLanAccessCode') || '';
+        if (!state.accessCode) {
+            showAccessGate();
+            return;
+        }
+        const authenticated = await verifyAccessCode();
+        if (!authenticated) return;
+    }
+    await loadApplication();
+}
+
+async function loadApplication() {
     await fetchTheme();
     applyTheme(state.activeTheme);
     populateThemeSwitcher();
@@ -96,6 +112,80 @@ function cacheDom() {
     dom.searchNext = document.getElementById('search-next');
     dom.searchClose = document.getElementById('search-close');
     dom.searchCount = document.getElementById('search-count');
+    dom.accessGate = document.getElementById('access-gate');
+    dom.accessForm = document.getElementById('access-form');
+    dom.accessCode = document.getElementById('access-code');
+    dom.accessError = document.getElementById('access-error');
+}
+
+/* =========================================================================
+   LAN access
+   ========================================================================= */
+function attachAccessGate() {
+    if (!dom.accessForm) return;
+    dom.accessForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const code = (dom.accessCode.value || '').replace(/\s/g, '');
+        if (!/^\d{8}$/.test(code)) {
+            setAccessError('Enter the complete eight-digit access code.');
+            return;
+        }
+        state.accessCode = code;
+        setAccessError('Checking code…');
+        const authenticated = await verifyAccessCode();
+        if (!authenticated) return;
+        sessionStorage.setItem('krakenLanAccessCode', code);
+        hideAccessGate();
+        await loadApplication();
+    });
+}
+
+async function verifyAccessCode() {
+    try {
+        const resp = await apiFetch('/api/theme');
+        if (resp.status === 429) {
+            const retryAfter = resp.headers.get('Retry-After') || '60';
+            setAccessError(`Too many attempts. Try again in ${retryAfter} seconds.`);
+            showAccessGate();
+            return false;
+        }
+        if (!resp.ok) {
+            setAccessError('That access code is not valid.');
+            state.accessCode = '';
+            sessionStorage.removeItem('krakenLanAccessCode');
+            showAccessGate();
+            return false;
+        }
+        return true;
+    } catch (error) {
+        console.error('Could not verify LAN access:', error);
+        setAccessError('Could not reach the ProjektKraken server.');
+        showAccessGate();
+        return false;
+    }
+}
+
+function showAccessGate() {
+    if (!dom.accessGate) return;
+    dom.accessGate.classList.remove('hidden');
+    if (dom.accessCode) dom.accessCode.focus();
+}
+
+function hideAccessGate() {
+    if (dom.accessGate) dom.accessGate.classList.add('hidden');
+    setAccessError('');
+}
+
+function setAccessError(message) {
+    if (dom.accessError) dom.accessError.textContent = message;
+}
+
+async function apiFetch(url, options = {}) {
+    const headers = new Headers(options.headers || {});
+    if (state.lanAccess && state.accessCode) {
+        headers.set('Authorization', `Bearer ${state.accessCode}`);
+    }
+    return fetch(url, { ...options, headers });
 }
 
 /* =========================================================================
@@ -103,7 +193,8 @@ function cacheDom() {
    ========================================================================= */
 async function fetchTheme() {
     try {
-        const resp = await fetch('/api/theme');
+        const resp = await apiFetch('/api/theme');
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = await resp.json();
         state.allThemes = data.themes || {};
         if (data.active_theme) state.activeTheme = data.active_theme;
@@ -421,7 +512,8 @@ function resetFilters() {
    ========================================================================= */
 async function fetchTags() {
     try {
-        const resp = await fetch('/api/tags');
+        const resp = await apiFetch('/api/tags');
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = await resp.json();
         state.availableTags = data.tags || [];
     } catch (e) {
@@ -452,7 +544,7 @@ async function fetchLongform() {
     if (filterJson) params.append('filter_json', filterJson);
 
     try {
-        const resp = await fetch(`/api/longform?${params.toString()}`);
+        const resp = await apiFetch(`/api/longform?${params.toString()}`);
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = await resp.json();
         renderSections(data.sections || []);

--- a/src/webserver/static/styles.css
+++ b/src/webserver/static/styles.css
@@ -896,3 +896,50 @@ mark.search-hit.active-hit {
     padding: 1rem 1.25rem;
   }
 }
+/* Authenticated LAN access gate */
+.access-gate {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: grid;
+    place-items: center;
+    padding: 24px;
+    background: var(--app-bg, #181a1f);
+}
+
+.access-gate.hidden {
+    display: none;
+}
+
+.access-card {
+    width: min(420px, 100%);
+    padding: 28px;
+    border: 1px solid var(--border, #3a3f4b);
+    border-radius: 10px;
+    background: var(--surface, #242832);
+    color: var(--text-main, #f0f1f3);
+}
+
+.access-card label,
+.access-card input,
+.access-card button {
+    display: block;
+    width: 100%;
+}
+
+.access-card input {
+    box-sizing: border-box;
+    margin: 8px 0 12px;
+    padding: 10px 12px;
+    border: 1px solid var(--border, #3a3f4b);
+    border-radius: 6px;
+    background: var(--app-bg, #181a1f);
+    color: var(--text-main, #f0f1f3);
+    font: inherit;
+    letter-spacing: 0.16em;
+}
+
+.access-error {
+    min-height: 1.4em;
+    color: var(--error, #ef6b73);
+}

--- a/src/webserver/templates/index.html
+++ b/src/webserver/templates/index.html
@@ -7,11 +7,24 @@ But, basically that changes <!doctype html>
   <title>ProjektKraken Longform</title>
   <script>
     window.__INITIAL_THEME__ = "{{ initial_theme }}";
+    window.__LAN_ACCESS__ = {{ "true" if lan_access else "false" }};
   </script>
   <link rel="stylesheet" href="/static/styles.css?v=3" />
 </head>
 
 <body>
+  <div id="access-gate" class="access-gate hidden" role="dialog" aria-modal="true"
+    aria-labelledby="access-title">
+    <form id="access-form" class="access-card">
+      <h2 id="access-title">LAN access required</h2>
+      <p>Enter the eight-digit code shown in ProjektKraken.</p>
+      <label for="access-code">Access code</label>
+      <input id="access-code" type="text" inputmode="numeric" autocomplete="one-time-code"
+        maxlength="9" placeholder="1234 5678" />
+      <p id="access-error" class="access-error" role="alert"></p>
+      <button class="btn btn-primary" type="submit">Open longform</button>
+    </form>
+  </div>
   <div id="app">
     <header>
       <div class="header-row">

--- a/tests/integration/test_longform_integration.py
+++ b/tests/integration/test_longform_integration.py
@@ -350,10 +350,10 @@ def test_mixed_events_and_entities(db_service, sample_events, sample_entities):
         conn, "events", "event-2", position=300.0, parent_id=None, depth=0
     )
 
+    longform_builder.ensure_all_items_indexed(conn)
     sequence = longform_builder.build_longform_sequence(conn)
 
-    # Note: ensure_all_items_indexed() adds all DB items to longform
-    # automatically, so we expect all 3 events + 2 entities = 5 total
+    # Explicit indexing adds all 3 events + 2 entities to the live document.
     assert len(sequence) == 5
 
     # Verify that the items we explicitly added are in the right order

--- a/tests/unit/test_longform_editor.py
+++ b/tests/unit/test_longform_editor.py
@@ -1,11 +1,13 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMessageBox
 
 from src.gui.widgets.longform.content import LongformContentWidget
 from src.gui.widgets.longform.editor import LongformEditorWidget
 from src.gui.widgets.longform.outline import LongformOutlineWidget
+from src.webserver.config import ServerConfig
 
 
 @pytest.fixture
@@ -196,6 +198,54 @@ def test_editor_initialization(editor_widget):
     assert editor_widget.content is not None
     assert editor_widget.findChild(LongformOutlineWidget) is not None
     assert editor_widget.findChild(LongformContentWidget) is not None
+
+
+def test_editor_exposes_separate_local_and_lan_actions(editor_widget):
+    assert editor_widget.btn_publish.text() == "Publish Locally"
+    assert editor_widget.btn_share_lan.text() == "Share on LAN..."
+
+
+def test_editor_starts_local_publishing_without_auth_prompt(editor_widget):
+    with patch.object(editor_widget.web_manager, "start_server") as start_server:
+        editor_widget._toggle_publish(True)
+
+    start_server.assert_called_once_with(
+        db_path=editor_widget.db_path,
+        share_on_lan=False,
+    )
+
+
+def test_editor_confirms_and_starts_lan_sharing(editor_widget):
+    with (
+        patch(
+            "src.gui.widgets.longform.editor.QMessageBox.question",
+            return_value=QMessageBox.StandardButton.Yes,
+        ),
+        patch.object(editor_widget.web_manager, "start_server") as start_server,
+    ):
+        editor_widget._toggle_lan_share(True)
+
+    start_server.assert_called_once_with(
+        db_path=editor_widget.db_path,
+        share_on_lan=True,
+    )
+
+
+def test_editor_displays_formatted_lan_access_code(editor_widget):
+    editor_widget.web_manager._thread = MagicMock()
+    editor_widget.web_manager._config = ServerConfig(
+        host="0.0.0.0",
+        lan_access=True,
+        access_code="01234567",
+    )
+
+    editor_widget._on_server_status_changed(
+        True,
+        "http://192.168.1.20:8000/longform",
+    )
+
+    assert editor_widget.btn_share_lan.isChecked()
+    assert editor_widget.access_code_label.text() == "Access code: 0123 4567"
 
 
 def test_editor_refresh_signal(editor_widget, qtbot):

--- a/tests/unit/test_longform_filtering.py
+++ b/tests/unit/test_longform_filtering.py
@@ -69,26 +69,21 @@ def test_read_all_longform_items_with_allowed_ids(mock_conn):
     assert "e2" not in ids
 
 
-def test_build_longform_sequence_skips_ensure_indexed_when_filtered(mock_conn):
-    """Test that build_longform_sequence skips ensure_all_items_indexed when allowed_ids is set."""
+def test_build_longform_sequence_never_indexes_items(mock_conn):
+    """Sequence construction remains read-only with or without filters."""
     with patch("src.services.longform_builder.ensure_all_items_indexed") as mock_ensure:
         with patch(
             "src.services.longform_builder.read_all_longform_items"
         ) as mock_read:
             mock_read.return_value = []
 
-            # Case 1: No filter -> Should call ensure
             longform_builder.build_longform_sequence(
                 mock_conn, "default", allowed_ids=None
             )
-            mock_ensure.assert_called_once()
-
-            mock_ensure.reset_mock()
-
-            # Case 2: Filter -> Should NOT call ensure
             longform_builder.build_longform_sequence(
                 mock_conn, "default", allowed_ids={"x"}
             )
+
             mock_ensure.assert_not_called()
 
 

--- a/tests/unit/test_web_service_manager_security.py
+++ b/tests/unit/test_web_service_manager_security.py
@@ -1,0 +1,57 @@
+"""Security behavior for local and LAN web-service startup."""
+
+import logging
+from unittest.mock import patch
+
+from src.services.web_service_manager import WebServiceManager
+
+
+def test_start_server_uses_localhost_by_default(qtbot) -> None:
+    manager = WebServiceManager()
+    statuses: list[tuple[bool, str]] = []
+    manager.status_changed.connect(lambda running, url: statuses.append((running, url)))
+
+    with patch("src.services.web_service_manager.WebServerThread") as thread_class:
+        manager.start_server(port=8123, db_path="world.kraken")
+
+    config = thread_class.call_args.args[0]
+    assert config.host == "127.0.0.1"
+    assert config.lan_access is False
+    assert config.access_code is None
+    assert statuses[-1] == (True, "http://127.0.0.1:8123/longform")
+
+
+def test_lan_server_generates_rotating_eight_digit_codes(qtbot, caplog) -> None:
+    manager = WebServiceManager()
+    caplog.set_level(logging.INFO)
+    statuses: list[tuple[bool, str]] = []
+    manager.status_changed.connect(lambda running, url: statuses.append((running, url)))
+
+    with (
+        patch("src.services.web_service_manager.WebServerThread") as thread_class,
+        patch.object(manager, "get_local_ip", return_value="192.168.1.20"),
+        patch("src.services.web_service_manager.secrets.randbelow", side_effect=[7, 8]),
+    ):
+        manager.start_server(
+            port=8123,
+            db_path="world.kraken",
+            share_on_lan=True,
+        )
+        first_config = thread_class.call_args.args[0]
+        assert first_config.host == "0.0.0.0"
+        assert first_config.access_code == "00000007"
+        assert manager.access_code == "00000007"
+        manager.stop_server()
+        assert manager.access_code is None
+
+        manager.start_server(
+            port=8123,
+            db_path="world.kraken",
+            share_on_lan=True,
+        )
+        second_config = thread_class.call_args.args[0]
+
+    assert second_config.access_code == "00000008"
+    assert statuses[0] == (True, "http://192.168.1.20:8123/longform")
+    assert "00000007" not in caplog.text
+    assert "00000008" not in caplog.text

--- a/tests/unit/test_webserver_security.py
+++ b/tests/unit/test_webserver_security.py
@@ -1,0 +1,214 @@
+"""Security regression tests for embedded longform publishing."""
+
+import json
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.core.events import Event
+from src.services.db_service import DatabaseService
+from src.services.longform_builder import insert_or_update_longform_meta
+from src.webserver.config import ServerConfig
+from src.webserver.server import _AccessCodeRateLimiter, create_app
+
+
+@pytest.fixture
+def published_db_path(tmp_path) -> str:
+    """Create a file-backed world with one published and one unindexed event."""
+    path = str(tmp_path / "published.kraken")
+    service = DatabaseService(path)
+    service.connect()
+    service.insert_event(
+        Event(
+            id="published",
+            name="Published",
+            description="Visible content",
+            lore_date=1.0,
+            attributes={"marker": "published"},
+        )
+    )
+    service.insert_event(
+        Event(
+            id="unindexed",
+            name="Unindexed",
+            description="Must not be indexed by HTTP",
+            lore_date=2.0,
+            attributes={"marker": "unchanged"},
+        )
+    )
+    assert service._connection is not None
+    insert_or_update_longform_meta(
+        service._connection,
+        "events",
+        "published",
+        position=100.0,
+    )
+    service.close()
+    return path
+
+
+def test_server_config_defaults_to_localhost() -> None:
+    config = ServerConfig()
+
+    assert config.host == "127.0.0.1"
+    assert config.lan_access is False
+    assert config.access_code is None
+
+
+@pytest.mark.parametrize("code", [None, "1234567", "123456789", "abcdefgh"])
+def test_lan_config_requires_eight_digit_code(code: str | None) -> None:
+    with pytest.raises(ValueError, match="eight-digit"):
+        ServerConfig(lan_access=True, access_code=code)
+
+
+def test_local_mode_does_not_require_authentication(published_db_path: str) -> None:
+    client = TestClient(create_app(ServerConfig(db_path=published_db_path)))
+
+    response = client.get("/api/longform")
+
+    assert response.status_code == 200
+    assert [section["id"] for section in response.json()["sections"]] == [
+        "published"
+    ]
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/api/theme", "/api/tags", "/api/toc", "/api/longform"],
+)
+def test_lan_mode_protects_every_api_endpoint(
+    published_db_path: str, path: str
+) -> None:
+    config = ServerConfig(
+        host="0.0.0.0",
+        db_path=published_db_path,
+        lan_access=True,
+        access_code="01234567",
+    )
+    client = TestClient(create_app(config))
+
+    missing = client.get(path)
+    wrong = client.get(path, headers={"Authorization": "Bearer 76543210"})
+    valid = client.get(path, headers={"Authorization": "Bearer 01234567"})
+
+    assert missing.status_code == 401
+    assert wrong.status_code == 401
+    assert valid.status_code == 200
+
+
+def test_lan_viewer_shell_and_health_remain_public(published_db_path: str) -> None:
+    config = ServerConfig(
+        host="0.0.0.0",
+        db_path=published_db_path,
+        lan_access=True,
+        access_code="01234567",
+    )
+    client = TestClient(create_app(config))
+
+    viewer = client.get("/longform")
+    assert viewer.status_code == 200
+    assert "LAN access required" in viewer.text
+    assert "window.__LAN_ACCESS__ = true" in viewer.text
+    assert "01234567" not in viewer.text
+    assert client.get("/static/app.js").status_code == 200
+    assert client.get("/health").status_code == 200
+
+
+def test_failed_access_codes_are_rate_limited(published_db_path: str) -> None:
+    config = ServerConfig(
+        host="0.0.0.0",
+        db_path=published_db_path,
+        lan_access=True,
+        access_code="01234567",
+    )
+    client = TestClient(create_app(config))
+
+    for _ in range(4):
+        response = client.get(
+            "/api/theme", headers={"Authorization": "Bearer 99999999"}
+        )
+        assert response.status_code == 401
+
+    successful = client.get(
+        "/api/theme", headers={"Authorization": "Bearer 01234567"}
+    )
+    limited = client.get(
+        "/api/theme", headers={"Authorization": "Bearer 99999999"}
+    )
+
+    assert successful.status_code == 200
+    assert limited.status_code == 429
+    assert int(limited.headers["Retry-After"]) > 0
+
+
+def test_rate_limiter_has_a_global_failure_bound() -> None:
+    limiter = _AccessCodeRateLimiter()
+
+    for index in range(29):
+        assert limiter.record_failure(f"client-{index}") is None
+
+    assert limiter.record_failure("client-29") is not None
+
+
+def test_http_get_does_not_index_missing_items(published_db_path: str) -> None:
+    before = _event_attributes(published_db_path, "unindexed")
+    client = TestClient(create_app(ServerConfig(db_path=published_db_path)))
+
+    response = client.get("/api/longform")
+
+    assert response.status_code == 200
+    assert _event_attributes(published_db_path, "unindexed") == before
+    assert "_longform" not in before
+
+
+def test_read_only_database_skips_initialization_and_rejects_writes(
+    published_db_path: str,
+) -> None:
+    service = DatabaseService(published_db_path, read_only=True)
+    with (
+        patch.object(service, "_init_schema") as init_schema,
+        patch.object(service, "_run_migrations") as run_migrations,
+    ):
+        service.connect()
+
+    init_schema.assert_not_called()
+    run_migrations.assert_not_called()
+    assert service._connection is not None
+    with pytest.raises(sqlite3.OperationalError, match="readonly"):
+        service._connection.execute(
+            "UPDATE events SET name = ? WHERE id = ?", ("Changed", "published")
+        )
+    service.close()
+
+
+@pytest.mark.parametrize("doc_id", ["bad/id", "a" * 65, "white space"])
+def test_invalid_doc_id_returns_422(
+    published_db_path: str, doc_id: str
+) -> None:
+    client = TestClient(create_app(ServerConfig(db_path=published_db_path)))
+
+    response = client.get("/api/longform", params={"doc_id": doc_id})
+
+    assert response.status_code == 422
+
+
+def test_maximum_length_doc_id_is_accepted(published_db_path: str) -> None:
+    client = TestClient(create_app(ServerConfig(db_path=published_db_path)))
+
+    response = client.get("/api/longform", params={"doc_id": "a" * 64})
+
+    assert response.status_code == 200
+
+
+def _event_attributes(db_path: str, event_id: str) -> dict:
+    connection = sqlite3.connect(db_path)
+    try:
+        row = connection.execute(
+            "SELECT attributes FROM events WHERE id = ?", (event_id,)
+        ).fetchone()
+        assert row is not None
+        return json.loads(row[0])
+    finally:
+        connection.close()


### PR DESCRIPTION
Default publishing to localhost and require an ephemeral access code for explicit LAN sharing. Keep HTTP database access read-only and prevent GET requests from indexing longform content.

Closes #115

## Summary by Sourcery

Secure longform web publishing by defaulting to localhost-only serving and introducing authenticated, rate-limited LAN sharing with ephemeral access codes.

New Features:
- Add explicit LAN sharing mode with ephemeral eight-digit access codes and client/global rate limiting for longform web publishing.
- Introduce a browser-side access gate that prompts for and validates the LAN access code before loading the longform UI.

Bug Fixes:
- Prevent HTTP longform requests from auto-indexing or mutating database content, keeping reads strictly read-only.
- Restrict longform document identifiers to a validated ASCII pattern to avoid malformed or unsafe IDs.

Enhancements:
- Make the embedded web server use read-only database connections for HTTP access and centralize explicit indexing in the worker path.
- Refine the longform editor UI with separate local publishing and LAN sharing controls, showing safe clickable URLs and formatted access codes.
- Tighten server configuration defaults to bind to localhost and validate LAN authentication settings.

Documentation:
- Update the changelog to document secure local publishing, authenticated LAN sharing, read-only HTTP access, and new security-focused tests.

Tests:
- Add unit and integration tests covering LAN authentication, rate limiting, read-only database behavior, doc-id validation, and HTTP non-indexing guarantees.
- Extend longform editor and web-service manager tests to cover local vs LAN modes, access code display, and security-related regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added separate localhost publishing and optional LAN sharing.
  - LAN sharing now displays a temporary eight-digit access code and requires authentication.
  - Added a protected access screen for shared LAN views.
  - Longform pages and document IDs now receive safer validation and read-only handling.

- **Bug Fixes**
  - Publishing now defaults to localhost-only access.
  - Added rate limiting and clearer handling for unauthorized or excessive requests.
  - Improved cleanup of sharing credentials when publishing stops or encounters errors.

- **Tests**
  - Added comprehensive coverage for publishing security, authentication, validation, and access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->