### PR TITLE
fix(packaging): allow pinned SciPy hook warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 **Project:** ProjektKraken  
 **Document:** Project Changelog  
 **Last Updated:** 2026-08-13
-**Commit:** 14dc35e5
+**Commit:** 803fb89d
 ---
 
 # Changelog
@@ -11,10 +11,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.19.2]
+
 ### Changed
 
 - *(2026-08-13)* **Release**: Bumped project and application metadata to
-  version 0.19.1.
+  version 0.19.2.
+
+### Fixed
+
+- *(2026-08-13)* **Packaging / Clean Runner**: Classified the optional SciPy
+  compatibility import warning emitted by the hash-pinned PyInstaller hooks.
 
 ## [0.19.1]
 
@@ -37,6 +44,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- *(2026-08-13)* **Release**: Bumped project and application metadata to
+  version 0.19.1.
 - *(2026-08-12)* **Release / Status**: Recognized plain and beta-package Git
   tags without moving the existing `0.19.0` release tag.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ last_updated: 2026-07-27
 
 ## Version
 
-**v0.19.1 (Beta)**
+**v0.19.2 (Beta)**
 **Projekt Kraken** is a desktop worldbuilding environment designed for the "Architect" persona. It treats history as the primary axis of the world, offering a timeline-first approach to lore creation.
 
 ## Screenshot
@@ -330,7 +330,7 @@ master/detail-map workflows are documented in the
 
 ## Version
 
-**v0.19.1 (Beta)**
+**v0.19.2 (Beta)**
 
 ## License
 

--- a/packaging/windows/package-contract.json
+++ b/packaging/windows/package-contract.json
@@ -3,6 +3,7 @@
     "MySQLdb",
     "psycopg2",
     "pysqlite2",
+    "scipy._lib.array_api_compat.numpy.fft",
     "scipy.special._cdflib",
     "tzdata"
   ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ProjektKraken"
-version = "0.19.1"
+version = "0.19.2"
 description = "Project Kraken - A Timeline/Wiki Application"
 requires-python = ">=3.13"
 authors = [

--- a/src/core/version.py
+++ b/src/core/version.py
@@ -1,3 +1,3 @@
 """Authoritative runtime version for ProjektKraken."""
 
-VERSION = "0.19.1"
+VERSION = "0.19.2"

--- a/tests/packaging/test_windows_package_contract.py
+++ b/tests/packaging/test_windows_package_contract.py
@@ -63,6 +63,18 @@ class WindowsPackageContractTests(unittest.TestCase):
         )
         self.assertIn('architecture = "x64"', script)
 
+    def test_known_optional_hidden_imports_are_explicit(self) -> None:
+        """Keep clean-runner PyInstaller warning exceptions reviewable."""
+        contract = json.loads(
+            (ROOT / "packaging/windows/package-contract.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertIn(
+            "scipy._lib.array_api_compat.numpy.fft",
+            contract["allowed_missing_hidden_imports"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Allows the optional SciPy compatibility hidden-import warning emitted by the hash-pinned PyInstaller hooks on windows-latest and bumps the beta package version to 0.19.2.\n\nValidated locally with packaging contracts, focused release tests, Ruff, and the full two-launch packaged smoke.

## Summary by Sourcery

Bump the beta release to version 0.19.2 and adjust Windows packaging to treat the optional SciPy compatibility hidden‑import warning as an allowed, documented exception.

Bug Fixes:
- Classify the SciPy compatibility hidden import emitted by hash‑pinned PyInstaller hooks as an allowed warning in the Windows packaging contract.

Documentation:
- Update changelog and README to document the 0.19.2 beta release and its packaging behavior change.

Tests:
- Add a packaging contract test to ensure known optional hidden imports, including the SciPy compatibility import, are explicitly listed and reviewable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version 0.19.2 (Beta).

* **Bug Fixes**
  * Improved Windows packaging compatibility by handling an optional SciPy import warning appropriately.

* **Documentation**
  * Updated the displayed project version and changelog with the 0.19.2 release information.

* **Tests**
  * Added coverage to verify the Windows packaging configuration allows the known optional SciPy import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->